### PR TITLE
Fixes to support new myProxy updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,16 +25,6 @@ const getMappings = () => {
   return data.mappings || {}
 }
 
-const domains = {
-  abc123: 'freedomains.dev',
-  gen123: 'general.gs',
-  hir192: 'hireme.fun',
-  lrn999: 'learnjs.tips',
-  n00033: 'n00b.city',
-  never8: 'neverhustle.club',
-  us1923: 'usemy.app'
-}
-
 const getFullDomain = (subDomain, domain) => {
   const prefix = subDomain ? `${subDomain}.` : ''
   return `${prefix}${domain}`
@@ -89,10 +79,13 @@ app.delete('/api/logs/:domain', (req, res) => {
 })
 
 app.get('/api/domains', (req, res) => {
-  const domainList = Object.entries(domains).map(([id, domain]) => {
-    return { id, domain }
+  fetch (`${myProxyApi}/availableDomains`, {
+    headers: {
+      authorization
+    }
   })
-  res.json(domainList)
+    .then(r => r.json())
+    .then(domains => res.json(domains))
 })
 
 app.use('/api/mappings', (req, res, next) => {

--- a/app.js
+++ b/app.js
@@ -7,6 +7,9 @@ const app = express()
 app.use(express.static('public'))
 app.use(express.json())
 
+const myProxyApi = process.env.MYPROXY_API
+const myProxyKey = process.env.MYPROXY_KEY
+
 const dataPath = './data.db'
 let data = {}
 fs.readFile(dataPath, (err, fileData) => {
@@ -37,7 +40,6 @@ const getFullDomain = (subDomain, domain) => {
   return `${prefix}${domain}`
 }
 
-const myProxyApi = 'http://165.227.55.105:2229/api'
 
 app.get('/isAvailable', (req, res) => {
   const { subDomain, domain } = req.query
@@ -55,7 +57,7 @@ app.get('/isAvailable', (req, res) => {
 app.get('/downloadConfig', (req, res) => {
   fetch(`${myProxyApi}/mappings/download/?fullDomain=${req.query.fullDomain}`, {
     headers: {
-      authorization: '6ecbeea1-6dcd-4d77-870b-fcc04b86d79a'
+      authorization: myProxyKey
     }
   }).then(r => {
     r.body.pipe(res)
@@ -67,7 +69,7 @@ app.get('/api/logs/:type/:domain', (req, res) => {
   const { type, domain } = req.params
   fetch(`${myProxyApi}/logs/${type}/${domain}`, {
     headers: {
-      authorization: '6ecbeea1-6dcd-4d77-870b-fcc04b86d79a'
+      authorization: myProxyKey
     }
   }).then(r => {
     r.body.pipe(res)
@@ -79,7 +81,7 @@ app.delete('/api/logs/:domain', (req, res) => {
   fetch(`${myProxyApi}/logs/${domain}`, {
     method: 'DELETE',
     headers: {
-      authorization: '6ecbeea1-6dcd-4d77-870b-fcc04b86d79a'
+      authorization: myProxyKey
     }
   }).then(r => {
     r.body.pipe(res)
@@ -105,9 +107,9 @@ app.use('/api/mappings', (req, res, next) => {
 })
 
 app.get('/api/mappings', async (req, res) => {
-  const originalMappings = await fetch('http://165.227.55.105:2229/api/mappings', {
+  const originalMappings = await fetch(`${myProxyApi}/mappings`, {
     headers: {
-      authorization: '6ecbeea1-6dcd-4d77-870b-fcc04b86d79a'
+      authorization: myProxyKey
     }
   }).then(r => r.json())
   const originalMap = originalMappings.reduce((acc, mapping) => {
@@ -137,11 +139,11 @@ app.delete('/api/mappings/:id', async (req, res) => {
     return res.status(401).json({ message: 'user id is invalid' })
   }
 
-  await fetch(`http://165.227.55.105:2229/api/mappings/${req.params.id}`, {
+  await fetch(`${myProxyApi}/mappings/${req.params.id}`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
-      authorization: '6ecbeea1-6dcd-4d77-870b-fcc04b86d79a'
+      authorization: myProxyKey
     }
   }).then(r => r.json()).catch(e => {
     console.log('error for deleting mapping', e)
@@ -156,11 +158,11 @@ app.delete('/api/mappings/:id', async (req, res) => {
 app.post('/api/mappings', async (req, res) => {
   const { subDomain, domain } = req.body
 
-  const newMapping = await fetch('http://165.227.55.105:2229/api/mappings', {
+  const newMapping = await fetch(`${myProxyApi}/mappings`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      authorization: '6ecbeea1-6dcd-4d77-870b-fcc04b86d79a'
+      authorization: myProxyKey
     },
     body: JSON.stringify({
       domain, subDomain
@@ -247,11 +249,11 @@ app.post('/api/sshKeys', async (req, res) => {
         }
 
         // Create new key
-        await fetch('http://165.227.55.105:2229/api/sshKeys', {
+        await fetch(`${myProxyApi}/sshKeys`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            authorization: '6ecbeea1-6dcd-4d77-870b-fcc04b86d79a'
+            authorization: myProxyKey
           },
           body: JSON.stringify({
             key

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "freedomains.dev",
   "version": "1.0.0",
   "description": "",
-  "main": "deploy.config.js",
+  "main": "app.js",
   "scripts": {
     "start:myproxy": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/public/index.html
+++ b/public/index.html
@@ -136,9 +136,12 @@ app.listen(process.env.PORT || 8123);
 
           <h5>3e: Tell MyProxy Server how to run your app</h5>
           <div class="indent">
-            Under the "scripts" section of package.json file, tell us how to run your app. Don't forget the "," at the end!
-            <br />
-            <img src="/step3.png" alt="">
+            Under the "main" section of package.json file, put the filename of your app main entry point.
+            <pre style="background-color: #f3f3f3; padding: 0 30px"><code>
+...
+"main": "app.js",
+....
+          </code></pre>
           </div>
 
           <h5>3f: Save and push!</h5>

--- a/public/index.js
+++ b/public/index.js
@@ -36,7 +36,7 @@ class MappingItem {
     // they are not managed by pm2.
     let settingClass
     let logClass
-    if (data.status === 'online') {
+    if (data.status === 'running') {
       iconClass = 'fa fa-circle mr-1 mt-1'
       iconColor = 'rgba(50,255,50,0.5)'
       logClass = 'fa fa-file-text-o ml-1 mt-1'
@@ -89,39 +89,18 @@ class MappingItem {
           <a
             class="${logClass}"
             style="font-size: 15px; color: rgba(255,50,50,0.5)"
-            href="/api/logs/err/${data.fullDomain}"
+            href="/api/logs/stderr/${data.fullDomain}"
           >
           </a>
           <a
             class="${logClass}"
             style="font-size: 15px; color: rgba(40,167,70,0.5)"
-            href="/api/logs/out/${data.fullDomain}"
+            href="/api/logs/stdout/${data.fullDomain}"
           >
           </a>
-          <div class="dropright">
-            <a href="#" role="button" data-toggle="dropdown" class="btn-link">
-              <span class="${settingClass}" style="font-size: 15px"> </span>
-            </a>
-            <div class="dropdown-menu">
-              <button
-                type="button"
-                class="btn btn-link deleteLogButton"
-                style="color: rgba(255,50,50,1)"
-              >
-                Clear Logs
-              </button>
-            </div>
-          </div>
         </div>
         ${step2Content}
       </div>
-      <a
-        href="/downloadConfig/?fullDomain=${data.fullDomain}"
-        target="_blank"
-        class="btn btn-sm btn-outline-success mr-3"
-      >
-        Download<i class="fa fa-download"></i>
-      </a>
       <button
         class="btn btn-sm btn-outline-danger mr-3 deleteButton"
         type="button"
@@ -139,18 +118,6 @@ class MappingItem {
             'Content-Type': 'application/json'
           }
         }).then(res => {
-          window.location.reload()
-        })
-      }
-    }
-    const clearLogButton = mappingElement.querySelector('.deleteLogButton')
-    clearLogButton.onclick = () => {
-      if (
-        confirm(`Are you sure you want to clear ${data.fullDomain}'s logs?`)
-      ) {
-        fetch(`/api/logs/${data.fullDomain}`, {
-          method: 'DELETE'
-        }).then(() => {
           window.location.reload()
         })
       }


### PR DESCRIPTION
This PR includes some initial fixes to make freedomains work with the new changes in myProxy.

* Fixed hardcoded URLs to the myProxy API server and access token.
    * These 2 values must now be set through environment variables: `MYPROXY_API` and `MYPROXY_KEY`.
* Fixed `/api/domains` endpoint to query the myProxy API for the available domains.
* Misc fixes for the frontend script to correct the logs links and remove unsupported features.