### PR TITLE
Fix log response content type

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,6 +62,7 @@ app.get('/api/logs/:type/:domain', (req, res) => {
       authorization: myProxyKey
     }
   }).then(r => {
+    res.type('json')
     r.body.pipe(res)
   })
 })

--- a/app.js
+++ b/app.js
@@ -62,7 +62,7 @@ app.get('/api/logs/:type/:domain', (req, res) => {
       authorization: myProxyKey
     }
   }).then(r => {
-    res.type('json')
+    res.setHeader('content-type', 'text/plain')
     r.body.pipe(res)
   })
 })


### PR DESCRIPTION
Set the content type in the response object to plain text to prevent the browser downloading it.